### PR TITLE
Change directive to creating element, remove unnecessary params

### DIFF
--- a/includeStatic.js
+++ b/includeStatic.js
@@ -1,16 +1,15 @@
 angular.module("static-include", []).directive('staticInclude', function($templateRequest, $compile) {
   return {
-    restrict: 'A',
-    transclude: true,
+    restrict: 'E',
+    transclude: 'element',
     replace: true,
-    scope: false,
-    link: function($scope, element, attrs, ctrl, transclude) {
-      var templatePath = attrs.staticInclude;
+    link: function(scope, element, attrs) {
+      var templatePath = attrs.src || attrs.staticInclude;
 
       $templateRequest(templatePath)
         .then(function(response) {
           var contents = element.html(response).contents();
-          $compile(contents)($scope.$new(false, $scope.$parent));
+          $compile(contents)(scope.$new(false, scope.$parent));
         });
     }
   };


### PR DESCRIPTION
Little fix if you dont mind ofc, i think this feature have more advantage with element-like style cuz:
```<static-include src='path'></static-include>```
looks really better than:
```<div static-include='path'></div>```
and names like $scope is not really good practice in link-function IMHO